### PR TITLE
fix: Typo on health_check endpoint

### DIFF
--- a/ragondin/api.py
+++ b/ragondin/api.py
@@ -96,8 +96,8 @@ async def get_answer(
         headers={"X-Metadata-Sources": src_json},
     )
 
-@app.get("/heath_check/", summary="Toy endpoint to check that the api is up")
-async def heath_check():
+@app.get("/health_check/", summary="Toy endpoint to check that the api is up")
+async def health_check():
     return "RAG API is up."
 
 

--- a/ragondin/chainlit/app_front.py
+++ b/ragondin/chainlit/app_front.py
@@ -75,7 +75,7 @@ async def on_chat_start():
         history.clear()
         logger.info("New Chat Started")
         async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
-            response = await client.get(url=base_url.format(method='heath_check'))
+            response = await client.get(url=base_url.format(method='health_check'))
             print(response.text)
     except:
         logger.warning("Make sur the fastapi is up!!")


### PR DESCRIPTION
BREAKING CHANGE: the `/heath_check` API endpoint is now replaced by `/health_check` as it had a typo in the name.