### PR TITLE
Docker compose for non cuda enabled devices

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,20 +1,27 @@
 include:
   - vdb/${VDB_HOST}.yaml
+
+x-chainlit-app: &chainlit_template
+  build: 
+    dockerfile: Dockerfile
+  volumes:
+    - ./model_weights:/app/model_weights
+    - ./data:/app/data # PDF data for RAG
+    - ./ragondin:/app/ragondin # For dev mode
+  ports:
+    - "${APP_PORT}:8080"
+  env_file:
+    - .env
+  
+  depends_on:
+    - ${VDB_HOST}
+
+
 services:
+
+  # GPU - default 
   chainlit-app:
-    build: 
-      dockerfile: Dockerfile
-    volumes:
-      - ./model_weights:/app/model_weights
-      - ./data:/app/data # PDF data for RAG
-      - ./ragondin:/app/ragondin # For dev mode
-    ports:
-      - "${APP_PORT}:8080"
-    env_file:
-      - .env
-    
-    depends_on:
-      - ${VDB_HOST}
+    <<: *chainlit_template
     deploy:
       resources:
         reservations:
@@ -22,3 +29,10 @@ services:
             - driver: nvidia
               count: all 
               capabilities: [gpu]
+
+  # No GPU (docker compose --profile cpu up)
+  chainlit-app-cpu:
+    <<: *chainlit_template
+    deploy: {}
+    profiles:
+      - cpu

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,10 +29,12 @@ services:
             - driver: nvidia
               count: all 
               capabilities: [gpu]
+    profiles:
+      - ''  # Empty string gives default behavior (but does not run when cpu requested)
 
   # No GPU (docker compose --profile cpu up)
   chainlit-app-cpu:
     <<: *chainlit_template
     deploy: {}
     profiles:
-      - cpu
+      - 'cpu'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ x-chainlit-app: &chainlit_template
     dockerfile: Dockerfile
   volumes:
     - ./model_weights:/app/model_weights
-    - ./data:/app/data # PDF data for RAG
+    - ./data/ragondin:/app/data # PDF data for RAG
     - ./ragondin:/app/ragondin # For dev mode
   ports:
     - "${APP_PORT}:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ x-chainlit-app: &chainlit_template
     dockerfile: Dockerfile
   volumes:
     - ./model_weights:/app/model_weights
-    - ./data/ragondin:/app/data # PDF data for RAG
+    - ./data:/app/data # PDF data for RAG
     - ./ragondin:/app/ragondin # For dev mode
   ports:
     - "${APP_PORT}:8080"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "debugpy>=1.8.13",
     "docling>=2.24.0",
     "einops>=0.8.1",
-    "fastembed-gpu>=0.4.2",
+    "fastembed>=0.4.2",
     "hydra-core>=1.3.2",
     "langchain-community>=0.3.18",
     "langchain-core>=0.3.39",
@@ -28,4 +28,9 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "pyyaml>=6.0.2",
     "ragatouille>=0.0.9",
+]
+
+[project.optional-dependencies]
+gpu = [
+    "fastembed-gpu",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "debugpy>=1.8.13",
     "docling>=2.24.0",
     "einops>=0.8.1",
-    "fastembed>=0.4.2",
+    "fastembed-gpu>=0.4.2",
     "hydra-core>=1.3.2",
     "langchain-community>=0.3.18",
     "langchain-core>=0.3.39",
@@ -28,9 +28,4 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "pyyaml>=6.0.2",
     "ragatouille>=0.0.9",
-]
-
-[project.optional-dependencies]
-gpu = [
-    "fastembed-gpu",
 ]


### PR DESCRIPTION
- Modified docker compose for non cuda enabled devices. This does not change anything for standard usage, but allows using the cpu profile to skip cuda initialization (which fails on macOS for example)