### PR TITLE
Proposal by @paultranvan, for conciseness

### DIFF
--- a/ragondin/api.py
+++ b/ragondin/api.py
@@ -66,12 +66,12 @@ def source2url(s: dict, static_base_url: str):
 
 
 @app.post(
-    "/{partition}/generate",
+    "/{namespace}/generate",
     summary="Given a question, this endpoint allows to generate an answer grounded on the documents in the VectorDB",
     tags=[Tags.LLM],
 )
 async def get_answer(
-    partition: str,
+    namespace: str,
     new_user_input: str,
     chat_history: list[ChatMsg] = None,
     static_base_url: str = Depends(static_base_url_dependency),
@@ -98,7 +98,7 @@ async def get_answer(
             for chat_msg in chat_history
         ]
     answer_stream, context, sources = await ragPipe.run(
-        partition=[partition], question=new_user_input, chat_history=msgs
+        partition=[namespace], question=new_user_input, chat_history=msgs
     )
     # print(sources)
     sources = list(map(lambda x: source2url(x, static_base_url), sources))
@@ -136,7 +136,7 @@ mount_chainlit(
 # Mount the indexer router
 app.include_router(indexer_router, prefix="/indexer", tags=[Tags.INDEXER])
 # Mount the search router
-app.include_router(search_router, prefix="/extracts", tags=[Tags.SEARCH])
+app.include_router(search_router, prefix="/search", tags=[Tags.SEARCH])
 # Mount the openai router
 app.include_router(openai_router, prefix="/v1", tags=[Tags.OPENAI])
 

--- a/ragondin/routers/search.py
+++ b/ragondin/routers/search.py
@@ -12,8 +12,8 @@ router = APIRouter()
 @router.get("/", response_model=None)
 async def search_multiple_partitions(
     request: Request,
-    partitions: Optional[List[str]] = Query(
-        ["all"], description="List of partitions to search"
+    namespace: Optional[List[str]] = Query(
+        ["all"], description="List of namespaces to search"
     ),
     text: str = Query(..., description="Text to search semantically"),
     top_k: int = Query(5, description="Number of top results to return"),
@@ -21,7 +21,7 @@ async def search_multiple_partitions(
 ):
     try:
         # Perform the search using the Indexer
-        results = await indexer.asearch(query=text, top_k=top_k, partition=partitions)
+        results = await indexer.asearch(query=text, top_k=top_k, partition=namespace)
 
         # Construct HATEOAS response
         documents = [
@@ -43,17 +43,17 @@ async def search_multiple_partitions(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/partition/{partition}", response_model=None)
+@router.get("/namespace/{namespace}", response_model=None)
 async def search_one_partition(
     request: Request,
-    partition: str,
+    namespace: str,
     text: str = Query(..., description="Text to search semantically"),
     top_k: int = Query(5, description="Number of top results to return"),
     indexer: Indexer = Depends(get_indexer),
 ):
     try:
         # Perform the search using the Indexer
-        results = await indexer.asearch(query=text, top_k=top_k, partition=partition)
+        results = await indexer.asearch(query=text, top_k=top_k, partition=namespace)
         # Transforming the results (assuming they are LangChain documents)
         # Construct HATEOAS response
         documents = [
@@ -75,10 +75,10 @@ async def search_one_partition(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/partition/{partition}/file/{file_id}", response_model=None)
+@router.get("/namespace/{namespace}/file/{file_id}", response_model=None)
 async def search_file(
     request: Request,
-    partition: str,
+    namespace: str,
     file_id: str,
     query: str = Query(..., description="Text to search semantically"),
     top_k: int = Query(5, description="Number of top results to return"),
@@ -87,7 +87,7 @@ async def search_file(
     try:
         # Perform the search using the Indexer
         results = await indexer.asearch(
-            query=query, top_k=top_k, partition=partition, filter={"file_id": file_id}
+            query=query, top_k=top_k, partition=namespace, filter={"file_id": file_id}
         )
 
         # Construct HATEOAS response
@@ -110,10 +110,10 @@ async def search_file(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/{extract_id}", response_model=None)
-async def get_extract(extract_id: str, indexer: Indexer = Depends(get_indexer)):
+@router.get("/{item_id}", response_model=None)
+async def get_extract(item_id: str, indexer: Indexer = Depends(get_indexer)):
     try:
-        doc = indexer.vectordb.get_chunk_by_id(extract_id)
+        doc = indexer.vectordb.get_chunk_by_id(item_id)
         return JSONResponse(
             content={"page_content": doc.page_content, "metadata": doc.metadata},
             status_code=200,


### PR DESCRIPTION
"Extracts" is pretty abstract and does not quite represent what the word is used for, this being a simple search. Since querying Ragondin is done through "generate", renaming "extracts" to "search" and "extract_id" to "item_id" seems appropriate.

A Partition is a concept quite particular to milvus. It may be better, especially if we plan on supporting other databases, to chose a broader nomenclature for the "space" a file is attached to, such as "namespace". This is purely a user-facing concern. I have not yet gone over all occurrences of "partition". If this decision is approved, I'll go ahead and do the rest.

We had discussed get requests having a body with @paultranvan, but upon reviewing the code, I could not seem to find any. I am mentioning it since it could be relevant.