### PR TITLE
Fix embedder model env variable doesn't match in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ RETRIEVER_TOP_K=5
 
 
 # EMBEDDER
-EMBEDDER_MODEL=jinaai/jina-embeddings-v3
+EMBEDDER_MODEL_NAME=jinaai/jina-embeddings-v3
 
 # RERANKER
 RERANKER_MODEL=jinaai/jina-colbert-v2


### PR DESCRIPTION
Embedder model name environment variable has been changed to `EMBEDDER_MODEL_NAME` in 
```sh 
.hydra_config/config.yaml:  model_name: ${oc.env:EMBEDDER_MODEL_NAME, HIT-TMG/KaLM-embedding-multilingual-mini-v1}
```
but remained `EMBEDDER_MODEL` in the `.env.example`.
